### PR TITLE
Add `bundle` script

### DIFF
--- a/packages/react-flying-saucer/bin/rfs.js
+++ b/packages/react-flying-saucer/bin/rfs.js
@@ -1,20 +1,23 @@
 #!/usr/bin/env node
 const path = require('path')
+const spawn = require('cross-spawn')
+
 const configPath = path.relative(
   process.cwd(),
   require.resolve('../craco-config.js')
 )
 
-const defaultArgs = `--config ${configPath}`.split(' ')
+const defaultArgs = ['--config', configPath]
 
 const args = process.argv.slice(2)
 const scriptIndex = args.findIndex(x => x === 'bundle')
 const script = scriptIndex === -1 ? args[0] : args[scriptIndex]
 
-let processArgs, verbose
+let verbose = false
+let processArgs
 
 switch (script) {
-  case 'assemble': {
+  case 'bundle': {
     const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : []
     const scriptPath = require.resolve(`../scripts/${script}`)
     const scriptArgs = args.slice(scriptIndex + 1)
@@ -27,7 +30,6 @@ switch (script) {
   }
   default:
     const scriptPath = require.resolve('@craco/craco/bin/craco.js')
-    verbose = false
     processArgs = [scriptPath].concat(args).concat(defaultArgs)
     break
 }

--- a/packages/react-flying-saucer/bin/scripts.js
+++ b/packages/react-flying-saucer/bin/scripts.js
@@ -5,7 +5,51 @@ const configPath = path.relative(
   require.resolve('../craco-config.js')
 )
 
-const args = `--config ${configPath}`
+const defaultArgs = `--config ${configPath}`.split(' ')
 
-process.argv.push(...args.split(' '))
-require('@craco/craco/bin/craco.js')
+const args = process.argv.slice(2)
+const scriptIndex = args.findIndex(x => x === 'bundle')
+const script = scriptIndex === -1 ? args[0] : args[scriptIndex]
+
+let processArgs, verbose
+
+switch (script) {
+  case 'assemble': {
+    const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : []
+    const scriptPath = require.resolve(`../scripts/${script}`)
+    const scriptArgs = args.slice(scriptIndex + 1)
+    verbose = true
+    processArgs = nodeArgs
+      .concat(scriptPath)
+      .concat(scriptArgs)
+      .concat(defaultArgs)
+    break
+  }
+  default:
+    const scriptPath = require.resolve('@craco/craco/bin/craco.js')
+    verbose = false
+    processArgs = [scriptPath].concat(args).concat(defaultArgs)
+    break
+}
+
+const child = spawn.sync('node', processArgs, { stdio: 'inherit' })
+
+if (verbose && child.signal) {
+  if (child.signal === 'SIGKILL') {
+    console.log(`
+            The build failed because the process exited too early.
+            This probably means the system ran out of memory or someone called
+            \`kill -9\` on the process.
+        `)
+  } else if (child.signal === 'SIGTERM') {
+    console.log(`
+            The build failed because the process exited too early.
+            Someone might have called  \`kill\` or \`killall\`, or the system could
+            be shutting down.
+        `)
+  }
+
+  process.exit(1)
+}
+
+process.exit(child.status)

--- a/packages/react-flying-saucer/craco-plugin.js
+++ b/packages/react-flying-saucer/craco-plugin.js
@@ -1,15 +1,11 @@
-const path = require('path')
 const {
   getLoaders,
   loaderByName,
   throwUnexpectedConfigError,
 } = require('@craco/craco')
 
-function getExternalFeatures() {
-  const package = require(path.resolve('package.json'))
-
-  return package.externalFeatures.map(name => path.resolve(name))
-}
+const merge = require('lodash/merge')
+const castArray = require('lodash/castArray')
 
 module.exports = {
   overrideWebpackConfig({ webpackConfig, cracoConfig }) {
@@ -33,26 +29,19 @@ module.exports = {
       loaderOptions,
     } = cracoConfig.customBabel
 
-    const externalFeatures = getExternalFeatures()
-
-    const external = [...externalPaths, ...externalFeatures]
-
     matches.forEach(({ loader }) => {
       if (loader.options.customize) {
-        Object.assign(loader.options, loaderOptions, {
-          presets: [...loader.options.presets, ...presets],
-          plugins: [...loader.options.plugins, ...plugins],
+        merge(loader.options, loaderOptions, {
+          presets,
+          plugins,
         })
 
-        if (external.length) {
-          loader.include = (Array.isArray(loader.include)
-            ? loader.include
-            : [loader.include]
-          ).concat(external)
+        if (externalPaths.length) {
+          loader.include = castArray(loader.include).concat(externalPaths)
 
           loader.exclude = {
             test: loader.exclude || /node_modules/,
-            not: external,
+            not: externalPaths,
           }
         }
       }

--- a/packages/react-flying-saucer/craco-plugin.js
+++ b/packages/react-flying-saucer/craco-plugin.js
@@ -4,7 +4,7 @@ const {
   throwUnexpectedConfigError,
 } = require('@craco/craco')
 
-const merge = require('lodash/merge')
+// const merge = require('lodash/merge')
 const castArray = require('lodash/castArray')
 
 module.exports = {
@@ -31,9 +31,12 @@ module.exports = {
 
     matches.forEach(({ loader }) => {
       if (loader.options.customize) {
-        merge(loader.options, loaderOptions, {
-          presets,
-          plugins,
+        const basePresets = loader.options.presets
+        const basePlugins = loader.options.plugins
+
+        Object.assign(loader.options, loaderOptions, {
+          presets: basePresets.concat(presets),
+          plugins: basePlugins.concat(plugins),
         })
 
         if (externalPaths.length) {

--- a/packages/react-flying-saucer/lib/rollup.js
+++ b/packages/react-flying-saucer/lib/rollup.js
@@ -1,0 +1,89 @@
+const path = require('path')
+const rollup = require('rollup')
+const { log } = require('@craco/craco/lib/logger')
+const { getLoader, loaderByName } = require('@craco/craco')
+
+const babel = require('rollup-plugin-babel')
+const commonjs = require('rollup-plugin-commonjs')
+const resolve = require('rollup-plugin-node-resolve')
+const minify = require('rollup-plugin-babel-minify')
+
+const { webpack } = require('../craco-config')
+
+const alias = aliases => ({
+  resolveId(importee) {
+    const alias = aliases[importee]
+
+    return alias ? this.resolveId(alias) : null
+  },
+})
+
+function bundle(name) {
+  return async configProvider => {
+    const { isFound, match } = getLoader(
+      configProvider,
+      loaderByName('babel-loader')
+    )
+
+    if (!isFound) {
+      throw new Error(
+        "craco: 'configProvider' does not contain a `babel-loader` configuration."
+      )
+    }
+
+    // remove webpack only config
+    const {
+      customize,
+      cacheDirectory,
+      cacheCompression,
+      cacheIdentifier,
+      ...options
+    } = match.loader.options
+
+    const inputOptions = {
+      input: 'src/index.js',
+      external: [
+        'react-flying-saucer',
+        'react-mothership',
+        'react',
+        'react-dom',
+        'lodash',
+      ],
+      plugins: [
+        alias(webpack.alias),
+        babel({
+          ...options,
+          runtimeHelpers: true,
+        }),
+        resolve({
+          jsnext: true,
+          main: true,
+          browser: true,
+        }),
+        commonjs(),
+        minify({
+          mangle: { topLevel: true },
+        }),
+      ],
+    }
+
+    const outputOptions = {
+      name,
+      file: 'dist/index.js',
+      format: 'umd',
+      sourcemap: true,
+      sourcemapFile: 'dist/index.js.map',
+    }
+
+    const bundle = await rollup.rollup(inputOptions)
+
+    log(`Bundling ${name} with dependencies:`)
+    log(bundle.watchFiles) // an array of file names this bundle depends on
+
+    await bundle.write(outputOptions)
+  }
+}
+
+module.exports = {
+  bundle,
+}

--- a/packages/react-flying-saucer/package-lock.json
+++ b/packages/react-flying-saucer/package-lock.json
@@ -951,6 +951,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@comandeer/babel-plugin-banner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@comandeer/babel-plugin-banner/-/babel-plugin-banner-4.1.0.tgz",
+      "integrity": "sha512-9hKVIN2+maygxkngnXDsZXRZqCYDY4pxIRljJqqJ5A+eJZzW3k/NZj5lixEmStjWFjlPlOHGYBytBehpf0l+hA=="
+    },
     "@craco/craco": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-3.4.0.tgz",
@@ -1006,6 +1011,16 @@
         "@svgr/core": "^2.4.1",
         "loader-utils": "^1.1.0"
       }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+    },
+    "@types/node": {
+      "version": "10.12.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.24.tgz",
+      "integrity": "sha512-GWWbvt+z9G5otRBW8rssOFgRY87J9N/qbhqfjMZ+gUuL6zoL+Hm6gP/8qQBG4jjimqdaNLCehcVapZ/Fs2WjCQ=="
     },
     "@types/q": {
       "version": "1.5.1",
@@ -1931,6 +1946,41 @@
         }
       }
     },
+    "babel-helper-evaluate-path": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
+      "integrity": "sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA=="
+    },
+    "babel-helper-flip-expressions": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+      "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0="
+    },
+    "babel-helper-is-nodes-equiv": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
+    },
+    "babel-helper-is-void-0": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+      "integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4="
+    },
+    "babel-helper-mark-eval-scopes": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+      "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI="
+    },
+    "babel-helper-remove-or-void": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+      "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA="
+    },
+    "babel-helper-to-multiple-sequence-expressions": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
+      "integrity": "sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA=="
+    },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
@@ -2015,6 +2065,87 @@
         "resolve": "^1.8.1"
       }
     },
+    "babel-plugin-minify-builtins": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
+      "integrity": "sha512-wpqbN7Ov5hsNwGdzuzvFcjgRlzbIeVv1gMIlICbPj0xkexnfoIDe7q+AZHMkQmAE/F9R5jkrB6TLfTegImlXag=="
+    },
+    "babel-plugin-minify-constant-folding": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
+      "integrity": "sha512-Vj97CTn/lE9hR1D+jKUeHfNy+m1baNiJ1wJvoGyOBUx7F7kJqDZxr9nCHjO/Ad+irbR3HzR6jABpSSA29QsrXQ==",
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0"
+      }
+    },
+    "babel-plugin-minify-dead-code-elimination": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.0.tgz",
+      "integrity": "sha512-XQteBGXlgEoAKc/BhO6oafUdT4LBa7ARi55mxoyhLHNuA+RlzRmeMAfc31pb/UqU01wBzRc36YqHQzopnkd/6Q==",
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0",
+        "babel-helper-mark-eval-scopes": "^0.4.3",
+        "babel-helper-remove-or-void": "^0.4.3",
+        "lodash.some": "^4.6.0"
+      }
+    },
+    "babel-plugin-minify-flip-comparisons": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+      "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
+      "requires": {
+        "babel-helper-is-void-0": "^0.4.3"
+      }
+    },
+    "babel-plugin-minify-guarded-expressions": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.3.tgz",
+      "integrity": "sha1-zHCbRFP9IbHzAod0RMifiEJ845c=",
+      "requires": {
+        "babel-helper-flip-expressions": "^0.4.3"
+      }
+    },
+    "babel-plugin-minify-infinity": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+      "integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco="
+    },
+    "babel-plugin-minify-mangle-names": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
+      "integrity": "sha512-3jdNv6hCAw6fsX1p2wBGPfWuK69sfOjfd3zjUXkbq8McbohWy23tpXfy5RnToYWggvqzuMOwlId1PhyHOfgnGw==",
+      "requires": {
+        "babel-helper-mark-eval-scopes": "^0.4.3"
+      }
+    },
+    "babel-plugin-minify-numeric-literals": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+      "integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw="
+    },
+    "babel-plugin-minify-replace": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
+      "integrity": "sha512-aXZiaqWDNUbyNNNpWs/8NyST+oU7QTpK7J9zFEFSA0eOmtUNMU3fczlTTTlnCxHmq/jYNFEmkkSG3DDBtW3Y4Q=="
+    },
+    "babel-plugin-minify-simplify": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.0.tgz",
+      "integrity": "sha512-TM01J/YcKZ8XIQd1Z3nF2AdWHoDsarjtZ5fWPDksYZNsoOjQ2UO2EWm824Ym6sp127m44gPlLFiO5KFxU8pA5Q==",
+      "requires": {
+        "babel-helper-flip-expressions": "^0.4.3",
+        "babel-helper-is-nodes-equiv": "^0.0.1",
+        "babel-helper-to-multiple-sequence-expressions": "^0.5.0"
+      }
+    },
+    "babel-plugin-minify-type-constructors": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+      "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
+      "requires": {
+        "babel-helper-is-void-0": "^0.4.3"
+      }
+    },
     "babel-plugin-named-asset-import": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.0.tgz",
@@ -2035,6 +2166,26 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
+    "babel-plugin-transform-inline-consecutive-adds": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+      "integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE="
+    },
+    "babel-plugin-transform-member-expression-literals": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
+      "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8="
+    },
+    "babel-plugin-transform-merge-sibling-variables": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
+      "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4="
+    },
+    "babel-plugin-transform-minify-booleans": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
+      "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg="
+    },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
@@ -2044,10 +2195,51 @@
         "babel-runtime": "^6.26.0"
       }
     },
+    "babel-plugin-transform-property-literals": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
+      "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.18.tgz",
       "integrity": "sha512-azed2nHo8vmOy7EY26KH+om5oOcWRs0r1U8wOmhwta+SBMMnmJ4H6yaBZRCcHBtMeWp9AVhvBTL/lpR1kEx+Xw=="
+    },
+    "babel-plugin-transform-regexp-constructors": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+      "integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU="
+    },
+    "babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A="
+    },
+    "babel-plugin-transform-remove-debugger": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
+      "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI="
+    },
+    "babel-plugin-transform-remove-undefined": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
+      "integrity": "sha512-+M7fJYFaEE/M9CXa0/IRkDbiV3wRELzA1kKQFCJ4ifhrzLKn/9VCCgj9OFmYWwBd8IB48YdgPkHYtbYq+4vtHQ==",
+      "requires": {
+        "babel-helper-evaluate-path": "^0.5.0"
+      }
+    },
+    "babel-plugin-transform-simplify-comparison-operators": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
+      "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk="
+    },
+    "babel-plugin-transform-undefined-to-void": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
+      "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA="
     },
     "babel-preset-jest": {
       "version": "23.2.0",
@@ -2056,6 +2248,36 @@
       "requires": {
         "babel-plugin-jest-hoist": "^23.2.0",
         "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+      }
+    },
+    "babel-preset-minify": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.0.tgz",
+      "integrity": "sha512-xj1s9Mon+RFubH569vrGCayA9Fm2GMsCgDRm1Jb8SgctOB7KFcrVc2o8K3YHUyMz+SWP8aea75BoS8YfsXXuiA==",
+      "requires": {
+        "babel-plugin-minify-builtins": "^0.5.0",
+        "babel-plugin-minify-constant-folding": "^0.5.0",
+        "babel-plugin-minify-dead-code-elimination": "^0.5.0",
+        "babel-plugin-minify-flip-comparisons": "^0.4.3",
+        "babel-plugin-minify-guarded-expressions": "^0.4.3",
+        "babel-plugin-minify-infinity": "^0.4.3",
+        "babel-plugin-minify-mangle-names": "^0.5.0",
+        "babel-plugin-minify-numeric-literals": "^0.4.3",
+        "babel-plugin-minify-replace": "^0.5.0",
+        "babel-plugin-minify-simplify": "^0.5.0",
+        "babel-plugin-minify-type-constructors": "^0.4.3",
+        "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
+        "babel-plugin-transform-member-expression-literals": "^6.9.4",
+        "babel-plugin-transform-merge-sibling-variables": "^6.9.4",
+        "babel-plugin-transform-minify-booleans": "^6.9.4",
+        "babel-plugin-transform-property-literals": "^6.9.4",
+        "babel-plugin-transform-regexp-constructors": "^0.4.3",
+        "babel-plugin-transform-remove-console": "^6.9.4",
+        "babel-plugin-transform-remove-debugger": "^6.9.4",
+        "babel-plugin-transform-remove-undefined": "^0.5.0",
+        "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
+        "babel-plugin-transform-undefined-to-void": "^6.9.4",
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "babel-preset-react-app": {
@@ -4514,6 +4736,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+    },
+    "estree-walker": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig=="
     },
     "esutils": {
       "version": "2.0.2",
@@ -7252,6 +7479,11 @@
         "is-extglob": "^1.0.0"
       }
     },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
+    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -8368,6 +8600,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8377,6 +8614,11 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -8435,6 +8677,14 @@
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -13379,6 +13629,84 @@
         "inherits": "^2.0.1"
       }
     },
+    "rollup": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.1.2.tgz",
+      "integrity": "sha512-OkdMxqMl8pWoQc5D8y1cIinYQPPLV8ZkfLgCzL6SytXeNA2P7UHynEQXI9tYxuAjAMsSyvRaWnyJDLHMxq0XAg==",
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "*",
+        "acorn": "^6.0.5"
+      }
+    },
+    "rollup-plugin-babel": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.2.tgz",
+      "integrity": "sha512-KfnizE258L/4enADKX61ozfwGHoqYauvoofghFJBhFnpH9Sb9dNPpWg8QHOaAfVASUYV8w0mCx430i9z0LJoJg==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "rollup-pluginutils": "^2.3.0"
+      }
+    },
+    "rollup-plugin-babel-minify": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel-minify/-/rollup-plugin-babel-minify-7.0.0.tgz",
+      "integrity": "sha512-ExLkt1yo1iNXVADxF/pq27/gk7mbGXhMUJybvUHDAw0Qw6F+Th7oWiuOsPcz+ylbmvmRu4l0/V3w1rdJuIT80Q==",
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+        "@comandeer/babel-plugin-banner": "^4.0.0",
+        "babel-preset-minify": "^0.5.0",
+        "sourcemap-codec": "^1.4.3"
+      },
+      "dependencies": {
+        "@babel/plugin-syntax-dynamic-import": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+          "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        }
+      }
+    },
+    "rollup-plugin-commonjs": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.0.tgz",
+      "integrity": "sha512-0RM5U4Vd6iHjL6rLvr3lKBwnPsaVml+qxOGaaNUWN1lSq6S33KhITOfHmvxV3z2vy9Mk4t0g4rNlVaJJsNQPWA==",
+      "requires": {
+        "estree-walker": "^0.5.2",
+        "magic-string": "^0.25.1",
+        "resolve": "^1.8.1",
+        "rollup-pluginutils": "^2.3.3"
+      }
+    },
+    "rollup-plugin-node-resolve": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.0.tgz",
+      "integrity": "sha512-7Ni+/M5RPSUBfUaP9alwYQiIKnKeXCOHiqBpKUl9kwp3jX5ZJtgXAait1cne6pGEVUUztPD6skIKH9Kq9sNtfw==",
+      "requires": {
+        "builtin-modules": "^3.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.8.1"
+      },
+      "dependencies": {
+        "builtin-modules": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
+          "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg=="
+        }
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",
+      "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
+      "requires": {
+        "estree-walker": "^0.5.2",
+        "micromatch": "^2.3.11"
+      }
+    },
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
@@ -14217,6 +14545,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg=="
     },
     "spdx-correct": {
       "version": "3.1.0",

--- a/packages/react-flying-saucer/package-lock.json
+++ b/packages/react-flying-saucer/package-lock.json
@@ -985,6 +985,33 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@rematch/core": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@rematch/core/-/core-1.0.6.tgz",
+      "integrity": "sha512-xz7tA3lJvMHbRXkKcjc4/fbTX3X7GjcfPojXq40Qdw5caF3B5tmu9lslpK9lcOhPk/nDeDqdF2WIrVQrFZAbRA==",
+      "requires": {
+        "redux": "4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+          "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.2.0"
+          }
+        }
+      }
+    },
+    "@rematch/select": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rematch/select/-/select-2.0.3.tgz",
+      "integrity": "sha512-sESP1SEmWGaGc6vaad9CiJAiDPvX0CqLKNb5Ul4VIfMC7qju3DE8609/Flgw6U/BJS2tTxdQy/X+BYYcAb3JNA==",
+      "requires": {
+        "reselect": "^3.0.1"
+      }
+    },
     "@svgr/core": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-2.4.1.tgz",
@@ -6675,6 +6702,14 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -9574,6 +9609,14 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -12339,6 +12382,98 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.2.tgz",
       "integrity": "sha512-7kEBKwU9R8fKnZJBRa5RSIfay4KJwnYvKB6gODGicUmDSAhQJ7Tdnll5S0RLtYrzRfMVXlqYw61rzrSpP4ThLQ=="
     },
+    "react-is": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
+      "integrity": "sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-mothership": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/react-mothership/-/react-mothership-0.0.23.tgz",
+      "integrity": "sha512-P5Y8p5Ov1RlYGjmVafFuwsIvXXdY2UFwlnplgaWrYrWsKSLWVfPeIiW7DKGVGi4anc5Lre4s4Udi8ktoBY/KbA==",
+      "requires": {
+        "@rematch/core": "^1.0.6",
+        "@rematch/select": "^2.0.3",
+        "lodash": "^4.17.11",
+        "react": "^16.7.0",
+        "react-redux": "^5.1.1",
+        "react-router": "^4.3.1",
+        "react-router-dom": "^4.3.1",
+        "redux": "^4.0.1",
+        "use-react-hooks": "^1.0.7"
+      }
+    },
+    "react-redux": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
+      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "hoist-non-react-statics": "^3.1.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.1",
+        "react-is": "^16.6.0",
+        "react-lifecycles-compat": "^3.0.0"
+      }
+    },
+    "react-router": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "requires": {
+        "history": "^4.7.2",
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.1",
+        "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        },
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
+      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+      "requires": {
+        "history": "^4.7.2",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.1",
+        "react-router": "^4.3.1",
+        "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
     "react-scripts": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-2.1.3.tgz",
@@ -13282,6 +13417,15 @@
         "minimatch": "3.0.4"
       }
     },
+    "redux": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -13547,6 +13691,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
     },
     "resolve": {
       "version": "1.9.0",
@@ -14892,6 +15041,11 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -15542,6 +15696,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-react-hooks": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/use-react-hooks/-/use-react-hooks-1.0.7.tgz",
+      "integrity": "sha512-QMV4FM3SRwauPYAGcGKvXFzw7u1rqTaI4hibwv9eiX5QlHP5bb2EIlO0XflBE1aAsxAdgvxlbmqVPye4+7+QIA=="
     },
     "util": {
       "version": "0.11.1",

--- a/packages/react-flying-saucer/package.json
+++ b/packages/react-flying-saucer/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.23",
   "description": "A zero-config way to write functional react apps that scale.",
   "bin": {
-    "react-flying-saucer": "./bin/scripts.js"
+    "react-flying-saucer": "./bin/rfs.js"
   },
   "main": "barrel.js",
   "files": [

--- a/packages/react-flying-saucer/package.json
+++ b/packages/react-flying-saucer/package.json
@@ -8,6 +8,8 @@
   "main": "barrel.js",
   "files": [
     "bin/",
+    "lib/",
+    "scripts/",
     "barrel.js",
     "craco-config.js",
     "craco-plugin.js"
@@ -36,9 +38,15 @@
     "eslint": "^5.6.0",
     "eslint-config-techno-babel": "^1.0.1",
     "history": "^4.7.2",
+    "lodash": "^4.17.11",
     "react": "^16.8.1",
     "react-mothership": "^0.0.23",
     "react-scripts": "^2.1.3",
+    "rollup": "^1.1.2",
+    "rollup-plugin-babel": "^4.3.2",
+    "rollup-plugin-babel-minify": "^7.0.0",
+    "rollup-plugin-commonjs": "^9.2.0",
+    "rollup-plugin-node-resolve": "^4.0.0",
     "webpack": "^4.28.4"
   },
   "peerDependencies": {

--- a/packages/react-flying-saucer/scripts/bundle.js
+++ b/packages/react-flying-saucer/scripts/bundle.js
@@ -1,0 +1,41 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  throw err
+})
+
+const path = require('path')
+const { bundle } = require('../lib/rollup')
+
+/*
+ * Add another craco script using its internals
+ * These might change in future releases
+ */
+const { log } = require('@craco/craco/lib/logger')
+const {
+  craPaths,
+  loadWebpackProdConfig,
+  overrideWebpackProdConfig,
+} = require('@craco/craco/lib/cra')
+const { loadCracoConfig } = require('@craco/craco/lib/config')
+const { overrideWebpack } = require('@craco/craco/lib/features/webpack')
+
+const loadPackage = () => require(craPaths.appPackageJson)
+
+log('Override started with arguments: ', process.argv)
+log('For environment: ', process.env.NODE_ENV)
+
+const context = {
+  env: process.env.NODE_ENV,
+  paths: craPaths,
+}
+
+const cracoConfig = loadCracoConfig(context)
+const craWebpackConfig = loadWebpackProdConfig()
+
+const package = loadPackage()
+
+overrideWebpack(cracoConfig, craWebpackConfig, bundle(package.name), context)


### PR DESCRIPTION
This lets a task runner bundle features in separate packages before they are imported.

things it does in addition to bundling:
- compiles with the craco babel config
- resolves aliases

The alternative is what I was toying with, where we whitelist certain `node_modules` - the _ placeholder plugin will throw an error on a lot of minified code without one.

In theory, this should precompile feature package specific stuff (bundling unique dependencies too) and then rely on webpack to correctly chunk it with `require` calls. This may not work well for a vendor chunk.