### PR TITLE
Fix babel runtime

### DIFF
--- a/packages/bundle-react-flying-saucer/lib/rollup.js
+++ b/packages/bundle-react-flying-saucer/lib/rollup.js
@@ -62,10 +62,12 @@ function getInputOptions(babelOptions, aliases = {}) {
       next(warning)
     },
     external: function(importee) {
-      // external if it doesn't start
-      // with a relative or absolute path
-      // assumes no one else can touch webpack.alias
-      return !/^([\.@]*\/|@@)/.test(importee)
+      // real paths: /<module>, ./<module>, ../<module>
+      // and aliases: @@, @/<module>
+      const localImport = !/^([.@]*\/|@@)/.test(importee)
+      const nodeModule = /node_modules/.test(importee)
+
+      return !localImport || nodeModule
     },
     plugins: [
       alias({

--- a/packages/craco-flying-saucer/index.js
+++ b/packages/craco-flying-saucer/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/craco-config')

--- a/packages/craco-flying-saucer/lib/craco-config.js
+++ b/packages/craco-flying-saucer/lib/craco-config.js
@@ -37,7 +37,7 @@ const jest = config => {
   config.moduleNameMapper = {
     ...config.moduleNameMapper,
     '@@$': 'react-flying-saucer',
-    '@(.*)$': '<rootDir>/src/$1',
+    '@/(.*)$': '<rootDir>/src/$1',
   }
 
   return config

--- a/packages/craco-flying-saucer/package.json
+++ b/packages/craco-flying-saucer/package.json
@@ -11,7 +11,7 @@
   "author": "Sam Richard <sam.richard@gmail.com>",
   "homepage": "https://github.com/d3dc/react-flying-saucer#readme",
   "license": "ISC",
-  "main": "index.js",
+  "main": "lib/craco-config.js",
   "files": [
     "index.js",
     "lib"


### PR DESCRIPTION
Because `absoluteRuntime` is on in `@babel/plugin-transform-runtime`, this checks the whole path for references to `node_modules` and makes them external.

Absolute paths that are external will be resolved to a relative path.