### PR TITLE
Update craco-config.js

### DIFF
--- a/packages/craco-flying-saucer/craco-config.js
+++ b/packages/craco-flying-saucer/craco-config.js
@@ -31,14 +31,12 @@ const eslint = {
   loaderOptions: { useEslintrc: true },
 }
 
-const jest = config => {
-  config.moduleNameMapper = {
-    ...config.moduleNameMapper,
-    '@@$': 'react-flying-saucer',
-    '@/(.*)$': '<rootDir>/src/$1',
-  }
-
-  return config
+const jest = {
+  configure: {
+    moduleNameMapper: {
+      '@@$': 'react-flying-saucer',
+      '@/(.*)$': '<rootDir>/src/$1',
+    },
 }
 
 const webpack = {


### PR DESCRIPTION
This patch should allow jest to run using the built-in aliases.